### PR TITLE
vodcount fix

### DIFF
--- a/src/main/java/io/antmedia/console/AdminApplication.java
+++ b/src/main/java/io/antmedia/console/AdminApplication.java
@@ -153,7 +153,7 @@ public class AdminApplication extends MultiThreadedApplicationAdapter {
 
 			if (scope != null && appName.equals(scope.getName())){
 
-				Object adapter = scope.getContext().getApplicationContext().getBean(AntMediaApplicationAdapter.BEAN_NAME);
+				Object adapter = ((IApplicationAdaptorFactory) scope.getContext().getApplicationContext().getBean(AntMediaApplicationAdapter.BEAN_NAME)).getAppAdaptor();
 				if (adapter instanceof AntMediaApplicationAdapter) 
 				{
 					DataStore dataStore = ((AntMediaApplicationAdapter)adapter).getDataStore();

--- a/src/main/java/io/antmedia/console/AdminApplication.java
+++ b/src/main/java/io/antmedia/console/AdminApplication.java
@@ -127,7 +127,7 @@ public class AdminApplication extends MultiThreadedApplicationAdapter {
 			ApplicationInfo info = new ApplicationInfo();
 			info.name = name;
 			info.liveStreamCount = getAppLiveStreamCount(getRootScope().getScope(name));
-			info.vodCount = getVoDCount(name);
+			info.vodCount = getVoDCount(getRootScope().getScope(name));
 
 			info.storage = getStorage(name);
 			appsInfo.add(info);
@@ -141,28 +141,17 @@ public class AdminApplication extends MultiThreadedApplicationAdapter {
 		return FileUtils.sizeOfDirectory(appFolder);
 	}
 
-	private int getVoDCount(String appName) {
-
-
-		IScope root = getRootScope();
-		java.util.Set<String> names = root.getScopeNames();
+	private int getVoDCount(IScope appScope) {
 		int size = 0;
-		for (String name : names) {
-
-			IScope scope = root.getScope(name);
-
-			if (scope != null && appName.equals(scope.getName())){
-
-				Object adapter = ((IApplicationAdaptorFactory) scope.getContext().getApplicationContext().getBean(AntMediaApplicationAdapter.BEAN_NAME)).getAppAdaptor();
-				if (adapter instanceof AntMediaApplicationAdapter) 
-				{
-					DataStore dataStore = ((AntMediaApplicationAdapter)adapter).getDataStore();
-					if (dataStore != null) {
-						size =  (int) dataStore.getTotalVodNumber();
-					}
+		if (appScope != null ){
+			Object adapter = ((IApplicationAdaptorFactory) appScope.getContext().getApplicationContext().getBean(AntMediaApplicationAdapter.BEAN_NAME)).getAppAdaptor();
+			if (adapter instanceof AntMediaApplicationAdapter)
+			{
+				DataStore dataStore = ((AntMediaApplicationAdapter)adapter).getDataStore();
+				if (dataStore != null) {
+					size =  (int) dataStore.getTotalVodNumber();
 				}
 			}
-
 		}
 
 		return size;


### PR DESCRIPTION
fixes https://github.com/ant-media/Ant-Media-Server/issues/2773
adapter object was streamapplication instead of AntMediaApplicationAdapter. So we are getting AntMediaApplicationAdapter now with getAppAdaptor call.
Also better optimization for getvodcount function. When there was like 100 applications, it was reiterating all the applications for every application to find right one, now it is O(1) access.